### PR TITLE
Async undo

### DIFF
--- a/.eslintrc.build.js
+++ b/.eslintrc.build.js
@@ -2,7 +2,8 @@
 module.exports = {
     extends: "./.eslintrc.js",
     rules: {
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      // Since this is prototype, having console.log message is useful
+      // "no-console": ["warn", { allow: ["warn", "error"] }],
       "no-debugger": "error"
     }
 };

--- a/doc/notes.md
+++ b/doc/notes.md
@@ -291,3 +291,20 @@ shared model is used. This is a bit mind bending, but might work...
 
 It does mean that the shared model and tree would both need to declare an id property.
 Also I wonder if the snapshots will apply correctly, it seems like they should. 
+
+# Recreating Problematic async case
+
+The timing of the undo of a node deletion is important:
+
+- the container has told the tile that it is done applying patches 
+- because of a delay in the system it is not actually done
+- the shared model is updated but the snapshot of it is sent to the tile after this finished message 
+- this triggers the tile's updateTreeAfterSharedModelChanges to run
+- the list tile will add a new item to its tree for the newly added shared model item
+- now the patches of the list item itself are sent to the list tile, these were also delayed
+  that is why they are happening late
+- at this point the patches create a new node in the list tile's tree
+- so now there are 2 new nodes in the list tile's tree instead of one.
+
+Additionally these 2 nodes have the same id and reference the same shared model item.
+An exception will be shown in the console because the keys of the elements in React match.

--- a/doc/notes.md
+++ b/doc/notes.md
@@ -311,8 +311,8 @@ An exception will be shown in the console because the keys of the elements in Re
 
 # Recreating Problematic async case 2
 
-With an artificial delay added to when the shared data model sends tells the
-container to update all tiles that are viewing it, a problem can occur. This is
+With an artificial delay added to when the shared data model tells the
+container to update all tiles that are viewing it, a problem can occur. This
 kind of delay seems unlikely since it seems in most cases shared models will be 
 running in the clue core.
 

--- a/src/models/container-api.ts
+++ b/src/models/container-api.ts
@@ -1,4 +1,11 @@
 
 export interface ContainerAPI {
-    updateSharedModel: (containerActionId: string, tileId: string, snapshot: any) => void;
+    // The returned promise should only resolve after the shared model has been updated
+    // in container and in all tiles that are using the shared model
+    // The promise does not guarantee that all of the tiles have updated their own 
+    // objects related to the shared model.
+    // In particular when this is called by a shared model when it is applying patches 
+    // from an undo or redo, the tiles will explicitly not update their related objects
+    // because the will receive patches that should contain these changes separately. 
+    updateSharedModel: (containerActionId: string, tileId: string, snapshot: any) => Promise<void>;
 }

--- a/src/models/container-api.ts
+++ b/src/models/container-api.ts
@@ -1,11 +1,20 @@
 
 export interface ContainerAPI {
-    // The returned promise should only resolve after the shared model has been updated
-    // in container and in all tiles that are using the shared model
-    // The promise does not guarantee that all of the tiles have updated their own 
-    // objects related to the shared model.
-    // In particular when this is called by a shared model when it is applying patches 
-    // from an undo or redo, the tiles will explicitly not update their related objects
-    // because the will receive patches that should contain these changes separately. 
-    updateSharedModel: (containerActionId: string, tileId: string, snapshot: any) => Promise<void>;
+    /**
+     * Propagate shared model state to other trees. 
+     * This is called by either a tile or a shared model
+     * 
+     * The shared model is identified by an id inside of the snapshot
+     * The sourceTreeId indicates which tree is sending this update.
+     * The new shared model snapshot will not be sent back to this source.
+     * 
+     * Note: The returned promise should only resolve after the shared model has been 
+     * updated in the container and in all tiles that are using the shared model
+     * The promise does not guarantee that all of the tiles have updated their own 
+     * objects related to the shared model.
+     * In particular when this is called by a shared model when it is applying patches 
+     * from an undo or redo, the tiles will explicitly not update their related objects
+     * because they will receive patches that should contain these changes separately.
+     */
+    updateSharedModel: (containerActionId: string, sourceTreeId: string, snapshot: any) => Promise<void>;
 }

--- a/src/models/container.ts
+++ b/src/models/container.ts
@@ -1,12 +1,13 @@
 // This model keeps the documents in sync
 
-import { Instance, types } from "mobx-state-tree";
+import { types } from "mobx-state-tree";
 import { DQRoot } from "./diagram/dq-root";
 import { ItemList } from "./item-list/item-list";
 import { SharedModel } from "./shared-model/shared-model";
 import { Tree } from "./tree";
 import { ContainerAPI } from "./container-api";
 import { UndoStore } from "./undo-manager/undo-store";
+import { TreeLike, TreeProxy } from "./tree-proxy";
 
 export const Container = ({initialDiagram, initialItemList, initialSharedModel}: any) => {
   
@@ -46,7 +47,14 @@ export const Container = ({initialDiagram, initialItemList, initialSharedModel}:
   const sharedModel = SharedModelTree.create(initialSharedModel, {undoStore, containerAPI});
   sharedModel.setupUndoRecorder();
 
-  const trees: Record<string, Instance<typeof Tree>> = {diagram, itemList, sharedModel};
+  // wrap the diagram and itemList in proxies to emulate what happens
+  // if they were running in iframes
+  // TODO: these models should not have direct access to the undoStore and containerAPI
+  const diagramProxy = new TreeProxy(diagram);
+  const itemListProxy = new TreeProxy(itemList);
+
+  const trees: Record<string, TreeLike> = {diagram: diagramProxy, itemList: itemListProxy, sharedModel};
+  // const trees: Record<string, TreeLike> = {diagram, itemList, sharedModel};
 
   return {diagram, itemList, sharedModel, undoStore};
 };

--- a/src/models/container.ts
+++ b/src/models/container.ts
@@ -30,13 +30,18 @@ export const Container = ({initialDiagram, initialItemList, initialSharedModel}:
       //    the tile views
       // If we support tiles having customized views of shared models then this will
       // need to become more complex.
-      for (const tree of Object.entries(trees)) {
-        if (tree[0] === sourceTreeId) continue;
-  
+      const applyPromises = Object.entries(trees).map(tree => {
+        if (tree[0] === sourceTreeId) {
+          return; 
+        }
+
         console.log(`repeating changes to ${tree[0]}`, snapshot);
   
-        tree[1].applySharedModelSnapshotFromContainer(containerActionId, snapshot);
-      }
+        return tree[1].applySharedModelSnapshotFromContainer(containerActionId, snapshot);
+      });
+      // The contract for this method is to return a Promise<void> so we need the extra
+      // then() at the end to do this.
+      return Promise.all(applyPromises).then();
     }
   };
 

--- a/src/models/container.ts
+++ b/src/models/container.ts
@@ -30,14 +30,14 @@ export const Container = ({initialDiagram, initialItemList, initialSharedModel}:
       //    the tile views
       // If we support tiles having customized views of shared models then this will
       // need to become more complex.
-      const applyPromises = Object.entries(trees).map(tree => {
-        if (tree[0] === sourceTreeId) {
+      const applyPromises = Object.entries(trees).map(([treeId, tree]) => {
+        if (treeId === sourceTreeId) {
           return; 
         }
 
-        console.log(`repeating changes to ${tree[0]}`, snapshot);
+        console.log(`repeating changes to ${treeId}`, snapshot);
   
-        return tree[1].applySharedModelSnapshotFromContainer(containerActionId, snapshot);
+        return tree.applySharedModelSnapshotFromContainer(containerActionId, snapshot);
       });
       // The contract for this method is to return a Promise<void> so we need the extra
       // then() at the end to do this.

--- a/src/models/item-list/item-list.ts
+++ b/src/models/item-list/item-list.ts
@@ -11,7 +11,6 @@ export const ItemListItem = types.model("ItemListItem", {
         // It is annoying but it seems like the observers added by components fire
         // before the the onInvalidated is called, so then this derived value is
         // recomputed.
-        console.log("itemList.getName");
         const sharedItem = tryReference(() => self.sharedItem);
         return sharedItem ? sharedItem.name : "invalid ref";
         // The user should really never see this invalid ref

--- a/src/models/shared-model/shared-model.ts
+++ b/src/models/shared-model/shared-model.ts
@@ -57,7 +57,9 @@ export const SharedModel = types.model("SharedModel", {
             // make sure this snapshot is for our shared model and not some other
             // shared model
             if (snapshot.id !== self.id) {
-                console.log("tried to apply shared model snapshot from different tree", {selfId: self.id, snapshot});
+                console.warn("tried to apply shared model snapshot from different tree. " +
+                    "The container should be improved to not send these snapshots.", 
+                    {selfId: self.id, snapshot});
                 return Promise.resolve();
             }
             applySnapshot(self, snapshot);

--- a/src/models/shared-model/shared-model.ts
+++ b/src/models/shared-model/shared-model.ts
@@ -79,7 +79,7 @@ export const SharedModel = types.model("SharedModel", {
             // Without the changes in the code to address this, the problem can be shown by:
             // 1. adding a node
             // 2. move the new node to the top of the list
-            // 3. delete th node
+            // 3. delete the node
             // 4. undo the last change.
             // If the shared model is not sent to the tile soon enough, then the tiles delete their
             // copy of the node since it is not yet in the shared model view. This will happen when

--- a/src/models/shared-model/shared-model.ts
+++ b/src/models/shared-model/shared-model.ts
@@ -86,16 +86,16 @@ export const SharedModel = types.model("SharedModel", {
             // the updateTreeAfterSharedModelChanges is called by the finishApplyingPatches call.
             // The updateTreeAfterSharedModelChanges deletes nodes because it is trying to keep the 
             // tile's references to these shared models in sync with the shared model.
-            // when the shared model is finally sent, this causes updateTreeAfterSharedModelChanges 
+            // When the shared model is finally sent, this causes updateTreeAfterSharedModelChanges 
             // to run again and now the tile recreates a node/item for this shared item.
             //
             // This has 2 effects:
             // - the internal state associated with the node/item is lost (its position in the list,
             // or position on the diagram)
             // - the undo stack will be broken because there will be changes applied outside of 
-            //   applyPatches, so these changes are recorded on the undo stack. So now the next undo 
+            //   applyPatchesFromUndo, so these changes are recorded on the undo stack. So now the next undo 
             //   will not go back in time, but instead just try to undo the mess that was caused
-            //   before. From testing this resulted in 3 entries added to the stack:
+            //   before. From testing messed up undo stack has 3 entries added to the stack:
             //   1. finishApplyingContainerPatches on the diagram with a removal of the node
             //   2. finishApplyingContainerPatches on the list with a a removal of the item
             //   3. a single entry with updateTreeAfterSharedModelChangesInternal actions from the 

--- a/src/models/tree-proxy.ts
+++ b/src/models/tree-proxy.ts
@@ -5,23 +5,23 @@
 // that it would use to communicate with the remote tree
 
 import { IJsonPatch, Instance } from "mobx-state-tree";
+import { delay } from "../utils/delay";
 import { Tree } from "./tree";
 
 // This proxy should also serve as a way to document the tile
 // API more concretely than the current Tree model does.
 
 export interface TreeLike {
-  startApplyingContainerPatches(): Promise<void>;
-  applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): Promise<void>;
-  finishApplyingContainerPatches(): Promise<void>;
+    startApplyingContainerPatches(): Promise<void>;
+    applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): Promise<void>;
+    finishApplyingContainerPatches(): Promise<void>;
 
-  applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void;
-}
-
-function delay(milliSeconds: number) {
-    return new Promise(function(resolve) { 
-        setTimeout(resolve, milliSeconds);
-    });
+    // The returned promise should resolve when all of the changes
+    // have been applied to the shared model view in the tree. 
+    // The promise should not wait for the rest of the tree to sync
+    // with these changes. This is because during the application of 
+    // undo patches this syncing shouldn't happen until later. 
+    applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): Promise<void>;
 }
 
 export class TreeProxy implements TreeLike {
@@ -44,7 +44,7 @@ export class TreeProxy implements TreeLike {
         // the patches from the tile
         return delay(0).then(() => this.tree.finishApplyingContainerPatches());
     }
-    applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void {
-        setTimeout(() => this.tree.applySharedModelSnapshotFromContainer(containerActionId, snapshot), 50);
+    applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any) {
+        return delay(50).then(() => this.tree.applySharedModelSnapshotFromContainer(containerActionId, snapshot));
     }
 } 

--- a/src/models/tree-proxy.ts
+++ b/src/models/tree-proxy.ts
@@ -11,11 +11,17 @@ import { Tree } from "./tree";
 // API more concretely than the current Tree model does.
 
 export interface TreeLike {
-  startApplyingContainerPatches(): void;
-  applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): void;
-  finishApplyingContainerPatches(): void;
+  startApplyingContainerPatches(): Promise<void>;
+  applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): Promise<void>;
+  finishApplyingContainerPatches(): Promise<void>;
 
   applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void;
+}
+
+function delay(milliSeconds: number) {
+    return new Promise(function(resolve) { 
+        setTimeout(resolve, milliSeconds);
+    });
 }
 
 export class TreeProxy implements TreeLike {
@@ -25,18 +31,18 @@ export class TreeProxy implements TreeLike {
         this.tree = tree;
     }
 
-    startApplyingContainerPatches(): void {
-        setTimeout(() => this.tree.startApplyingContainerPatches(), 0);
+    startApplyingContainerPatches() {
+        return delay(0).then(() => this.tree.startApplyingContainerPatches());
     }
-    applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): void {
-        setTimeout(() => this.tree.applyPatchesFromUndo(patchesToApply), 100);
+    applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]) {
+        return delay(100).then(() => this.tree.applyPatchesFromUndo(patchesToApply));
     }
-    finishApplyingContainerPatches(): void {
+    finishApplyingContainerPatches() {
         // To create a problematic situation, the timeout is set so the finish call occurs before 
         // the patches from the undo are applied to the tile. 
         // And the shared model changes coming from the container are applied before the 
         // the patches from the tile
-        setTimeout(() => this.tree.finishApplyingContainerPatches(), 0);
+        return delay(0).then(() => this.tree.finishApplyingContainerPatches());
     }
     applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void {
         setTimeout(() => this.tree.applySharedModelSnapshotFromContainer(containerActionId, snapshot), 50);

--- a/src/models/tree-proxy.ts
+++ b/src/models/tree-proxy.ts
@@ -1,0 +1,44 @@
+// This module will provide a proxy of the actual tree model
+// the goal is to emulate what would be required if the tree
+// was running in an iframe or worker.
+// The container would have one of these proxy implementations
+// that it would use to communicate with the remote tree
+
+import { IJsonPatch, Instance } from "mobx-state-tree";
+import { Tree } from "./tree";
+
+// This proxy should also serve as a way to document the tile
+// API more concretely than the current Tree model does.
+
+export interface TreeLike {
+  startApplyingContainerPatches(): void;
+  applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): void;
+  finishApplyingContainerPatches(): void;
+
+  applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void;
+}
+
+export class TreeProxy implements TreeLike {
+    tree: Instance<typeof Tree>;
+
+    constructor(tree: Instance<typeof Tree>) {
+        this.tree = tree;
+    }
+
+    startApplyingContainerPatches(): void {
+        setTimeout(() => this.tree.startApplyingContainerPatches(), 0);
+    }
+    applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]): void {
+        setTimeout(() => this.tree.applyPatchesFromUndo(patchesToApply), 100);
+    }
+    finishApplyingContainerPatches(): void {
+        // To create a problematic situation, the timeout is set so the finish call occurs before 
+        // the patches from the undo are applied to the tile. 
+        // And the shared model changes coming from the container are applied before the 
+        // the patches from the tile
+        setTimeout(() => this.tree.finishApplyingContainerPatches(), 0);
+    }
+    applySharedModelSnapshotFromContainer(containerActionId: string, snapshot: any): void {
+        setTimeout(() => this.tree.applySharedModelSnapshotFromContainer(containerActionId, snapshot), 50);
+    }
+} 

--- a/src/models/tree.ts
+++ b/src/models/tree.ts
@@ -2,7 +2,7 @@ import { types, applySnapshot, IJsonPatch, applyPatch, Instance, getEnv, getPath
 import { ContainerAPI } from "./container-api";
 import { SharedModel } from "./shared-model/shared-model";
 import { createUndoRecorder, SharedModelsConfig } from "./undo-manager/undo-recorder";
-import { TileUndoEntry } from "./undo-manager/undo-store";
+import { TreeUndoEntry } from "./undo-manager/undo-store";
 
 export const Tree = types.model("Tree", {
     id: types.identifier
@@ -104,7 +104,7 @@ export const Tree = types.model("Tree", {
             createUndoRecorder(self, (entry) => {
                 console.log("recording undoable action", {treeId: self.id, ...entry});
                 undoStore.addUndoEntry(entry.containerActionId, 
-                    TileUndoEntry.create({
+                    TreeUndoEntry.create({
                         tileId: self.id, 
                         actionName: entry.actionName, 
                         patches: entry.patches, 

--- a/src/models/tree.ts
+++ b/src/models/tree.ts
@@ -160,6 +160,11 @@ export const Tree = types.model("Tree", {
         // The container calls this before it calls applyPatchesFromUndo
         startApplyingContainerPatches() {
             self.applyingContainerPatches = true;
+
+            // We return a promise because the API is async
+            // The action itself doesn't do anything asynchronous though
+            // so it isn't necessary to use a flow
+            return Promise.resolve();
         },
 
         // This is defined as an action so it is clear that is part of the API
@@ -168,6 +173,10 @@ export const Tree = types.model("Tree", {
         // It might be called multiple times after startApplyingContainerPatches
         applyPatchesFromUndo(patchesToApply: readonly IJsonPatch[]) {
             applyPatch(self, patchesToApply);
+            // We return a promise because the API is async
+            // The action itself doesn't do anything asynchronous though
+            // so it isn't necessary to use a flow
+            return Promise.resolve();
         },
 
         // The container calls this after all patches have been applied
@@ -211,6 +220,11 @@ export const Tree = types.model("Tree", {
             // updateTreeAfterSharedModelChanges. And that will be likely to happen 
             // during development.
             self.updateTreeAfterSharedModelChanges();
+
+            // We return a promise because the API is async
+            // The action itself doesn't do anything asynchronous though
+            // so it isn't necessary to use a flow
+            return Promise.resolve();
         },
     };
     

--- a/src/models/tree.ts
+++ b/src/models/tree.ts
@@ -155,6 +155,13 @@ export const Tree = types.model("Tree", {
                 return;
             }
             applySnapshot(model, snapshot);
+
+            // The contract is that the promise we return should not resolve
+            // until all of the changes have been applied to shared model.
+            // We should not wait until the tree has run 
+            // updateTreeAfterSharedModelChanges
+            // So we can just resolve immediately
+            return Promise.resolve();
         },
 
         // The container calls this before it calls applyPatchesFromUndo

--- a/src/models/tree.ts
+++ b/src/models/tree.ts
@@ -104,11 +104,11 @@ export const Tree = types.model("Tree", {
             createUndoRecorder(self, (entry) => {
                 console.log("recording undoable action", {treeId: self.id, ...entry});
                 undoStore.addUndoEntry(entry.containerActionId, 
-                TileUndoEntry.create({
-                    tileId: self.id, 
-                    actionName: entry.actionName, 
-                    patches: entry.patches, 
-                    inversePatches: entry.inversePatches})
+                    TileUndoEntry.create({
+                        tileId: self.id, 
+                        actionName: entry.actionName, 
+                        patches: entry.patches, 
+                        inversePatches: entry.inversePatches})
                 );
             }, false, sharedModelsConfig );
         },

--- a/src/models/undo-manager/undo-store.ts
+++ b/src/models/undo-manager/undo-store.ts
@@ -1,10 +1,5 @@
 import {
-    types,
-    IJsonPatch,
-    Instance,
-    getSnapshot,
-    getEnv,
-    flow
+    types, IJsonPatch, Instance, getSnapshot, getEnv, flow
 } from "mobx-state-tree";
 import { TreeLike } from "../tree-proxy";
 

--- a/src/models/undo-manager/undo-store.ts
+++ b/src/models/undo-manager/undo-store.ts
@@ -5,6 +5,7 @@ import {
     getSnapshot,
     getEnv
 } from "mobx-state-tree";
+import { TreeLike } from "../tree-proxy";
 
 // I don't know if it is worth making this a MST model
 // we aren't planning to save the undo stack across sessions
@@ -37,6 +38,10 @@ enum OperationType {
     Redo = "redo",
 }
 
+interface Environment {
+    getTreeFromId: (treeId: string) => TreeLike;
+}
+
 export const UndoStore = types
     .model("UndoStore", {
         history: types.array(UndoEntry),
@@ -61,7 +66,7 @@ export const UndoStore = types
     }))
     .actions((self) => {
         const applyPatchesToComponents = (entryToUndo: Instance<typeof UndoEntry>, opType: OperationType ) => {
-            const getTreeFromId = getEnv(self).getTreeFromId;
+            const getTreeFromId = (getEnv(self) as Environment).getTreeFromId;
 
             // first disable shared model syncing in the model
             entryToUndo.tileEntries.forEach(tileEntry => {

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,6 @@
+export function delay(milliSeconds: number) {
+    return new Promise(function(resolve) { 
+        setTimeout(resolve, milliSeconds);
+    });
+}
+


### PR DESCRIPTION
This adds async support to the undo system.
To make sure the changes fixed real async problems, there are artificial delays introduced to cause problems.

Also there is a new TreeProxy class that is used to add some of these delays.
The TreeProxy could be used in the real system to provide bridge between the container and a tile that is running in an iframe.

There are now just 2 `FIXME`s left. One of them I'll fix when working on state saving. 

There are 21 TODOs. Some new ones added in this PR. I think many of those can be left until we try to integrate this approach in to CLUE. Perhaps all this will change with the new yjs stuff. 🤷 